### PR TITLE
Update Wolf Sheep instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ document.body.onload = function() {
       {
         "action" : "chance",
         "blockColor" : "#89a",
-        "format" : "ifelse random 100 < {0}",
+        "format" : "if random 100 < {0}",
         "clauses" : [ ],
         "params" : [
           {


### PR DESCRIPTION
The `chance` block is written to generate `ifelse` as its NetLogo code, but that causes a compiler error, since there's no "else" block being generated.